### PR TITLE
[FEAT][gen:api] 출력 결정성 개선 및 TanStack Query v5 타입 호환성 수정

### DIFF
--- a/.changeset/curly-cycles-search.md
+++ b/.changeset/curly-cycles-search.md
@@ -1,0 +1,5 @@
+---
+'@toktokhan-dev/cli-plugin-gen-api-react-query': patch
+---
+
+gen:api 출력 결정성 개선(import/타입 정렬), 멀티라인 import 병합 수정, organize-imports 복원, TanStack Query v5 타입 호환성 수정

--- a/packages/cli-plugins/gen-api-react-query/src/index.ts
+++ b/packages/cli-plugins/gen-api-react-query/src/index.ts
@@ -209,7 +209,16 @@ export const genApi = defineCommand<'gen:api', GenerateSwaggerApiConfig>({
         for (const file of files) {
           try {
             const raw = fs.readFileSync(file, 'utf8')
-            const formatted = await prettierString(raw, {
+            let organized = raw
+            try {
+              organized = await prettierString(raw, {
+                parser: 'babel-ts',
+                plugins: ['prettier-plugin-organize-imports'],
+              })
+            } catch {
+              // prettier-plugin-organize-imports not installed, skip
+            }
+            const formatted = await prettierString(organized, {
               parser: 'typescript',
               configPath,
             })
@@ -233,8 +242,9 @@ export function mergeTypeScriptContent(
   newContent: string,
 ): string {
   // 1) import 구문 보존 및 병합 (양쪽 모두에서 수집)
-  const importRegex = /^\s*import\s+[^;]*;\s*$/gm
-  const sideEffectImportRegex = /^\s*import\s+['"][^'"]+['"];\s*$/gm
+  // 멀티라인 import도 매칭: import { \n A, \n B \n } from '...';
+  const importRegex = /^\s*import\s+[\s\S]*?from\s*['"][^'"]*['"];?/gm
+  const sideEffectImportRegex = /^\s*import\s*['"][^'"]+['"];\s*$/gm
 
   const collectImports = (content: string) => {
     const imports = new Set<string>()

--- a/packages/cli-plugins/gen-api-react-query/src/index.ts
+++ b/packages/cli-plugins/gen-api-react-query/src/index.ts
@@ -184,7 +184,14 @@ export const genApi = defineCommand<'gen:api', GenerateSwaggerApiConfig>({
       await withLoading('Prettier format', covered.output, async () => {
         const fs = await import('fs')
         const pathMod = await import('path')
-        const { prettierString } = await import('@toktokhan-dev/node')
+        const { prettierString, findFileToTop } = await import(
+          '@toktokhan-dev/node'
+        )
+
+        // output 디렉토리 기준으로 prettier config를 탐색 (cwd 의존 제거)
+        const configPath =
+          findFileToTop(covered.output, '.prettierrc.js') || 'auto'
+
         const listTsFiles = (dir: string): string[] => {
           const entries = fs.readdirSync(dir, { withFileTypes: true })
           const files: string[] = []
@@ -204,7 +211,7 @@ export const genApi = defineCommand<'gen:api', GenerateSwaggerApiConfig>({
             const raw = fs.readFileSync(file, 'utf8')
             const formatted = await prettierString(raw, {
               parser: 'typescript',
-              configPath: 'auto',
+              configPath,
             })
             fs.writeFileSync(file, formatted)
           } catch {
@@ -247,7 +254,7 @@ export function mergeTypeScriptContent(
   // import 병합: 새 파일 기준 우선 순서 + 기존에만 있는 import 추가
   const mergedImportSet = new Set<string>(newImports)
   existingImports.forEach((imp) => mergedImportSet.add(imp))
-  const mergedImports = Array.from(mergedImportSet)
+  const mergedImports = Array.from(mergedImportSet).sort()
 
   // 2) 타입 선언 병합 (중복 제거)
   const existingTypes = parseTypeDefinitions(existingBody)
@@ -257,7 +264,10 @@ export function mergeTypeScriptContent(
   // 기존에만 있는 타입은 보존 (사용자가 수동 추가한 것)
   const mergedTypes = { ...existingTypes, ...newTypes }
 
-  const mergedTypesString = Object.values(mergedTypes).join('\n\n')
+  const mergedTypesString = Object.entries(mergedTypes)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([, v]) => v)
+    .join('\n\n')
 
   // 3) 기타 코드(타입/임포트 외)는 "새로운 내용"을 기준으로 유지
   const removeHeaderComment = (content: string): string => {

--- a/packages/cli-plugins/gen-api-react-query/src/parse-swagger.ts
+++ b/packages/cli-plugins/gen-api-react-query/src/parse-swagger.ts
@@ -31,6 +31,8 @@ export const parseSwagger = (
     input: config.swaggerSchemaUrl,
     httpClientType: config.httpClientType, // "axios" or "fetch"
     typeSuffix: 'Type',
+    sortTypes: true,
+    sortRoutes: true,
     prettier: {
       printWidth: 120,
     },

--- a/packages/cli-plugins/gen-api-react-query/src/write-swagger.ts
+++ b/packages/cli-plugins/gen-api-react-query/src/write-swagger.ts
@@ -1,8 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 
-import { prettierString } from '@toktokhan-dev/node'
-
 import { camelCase, upperFirst } from 'lodash'
 import { GenerateApiOutput } from 'swagger-typescript-api'
 
@@ -95,20 +93,20 @@ export const writeSwaggerApiFile = async (params: {
           filename,
           processedContent,
         )
-        await generatePretty(
+        generate(
           path.resolve(targetFolder, `${filename}.api.ts`),
           apiContents,
         )
 
         if (config.includeReactQuery) {
-          await generatePretty(
+          generate(
             path.resolve(targetFolder, `${filename}.query.ts`),
             hookParts[0],
           )
         }
 
         if (config.includeReactSuspenseQuery) {
-          await generatePretty(
+          generate(
             path.resolve(targetFolder, `${filename}.suspenseQuery.ts`),
             hookParts[1],
           )
@@ -248,27 +246,6 @@ export function extractImportedTypeNames(content: string): Set<string> {
       .map((s) => s.trim())
       .filter(Boolean),
   )
-}
-
-async function generatePretty(path: string, contents: string) {
-  let organized = contents
-  try {
-    organized = await prettierString(contents, {
-      parser: 'babel-ts',
-      plugins: ['prettier-plugin-organize-imports'],
-    })
-  } catch (err) {
-    console.warn(
-      '⚠️  prettier-plugin-organize-imports not found, skipping import organization',
-    )
-  }
-
-  const formatted = await prettierString(organized, {
-    parser: 'typescript',
-    configPath: 'auto',
-  })
-
-  generate(path, formatted)
 }
 
 function generate(path: string, contents: string) {

--- a/packages/cli-plugins/gen-api-react-query/templates/custom-axios/data-contracts.eta
+++ b/packages/cli-plugins/gen-api-react-query/templates/custom-axios/data-contracts.eta
@@ -36,7 +36,7 @@
       return `${keyName} : "${enumNames?.[idx]}"`;
     }).join(", ");
 
-    return `type ${contract.name} = keyof typeof ${mapName};  export const ${mapName} = {\r\n${map} \r\n } as const`;
+    return `type ${contract.name} = keyof typeof ${mapName};  export const ${mapName} = {\n${map} \n } as const`;
 
     },
     interface: (contract) => {
@@ -49,7 +49,7 @@
         content = content.replace(field, `${field} | null`)
       })
 
-      return `interface ${contract.name} {\r\n${content}}`;
+      return `interface ${contract.name} {\n${content}}`;
     },
     type: (contract) => {
       return `type ${contract.name} = ${contract.content}`;
@@ -83,8 +83,7 @@
 <% if (description.length) { %>
 /**
 <%~ description.map(part => `* ${part}`).join("\n") %>
-
-*/
+ */
 <% } %>
 export <%~ (dataContractTemplates[contract.typeIdentifier] || dataContractTemplates.type)(contract) %>
 

--- a/packages/cli-plugins/gen-api-react-query/templates/custom-fetch/data-contracts.eta
+++ b/packages/cli-plugins/gen-api-react-query/templates/custom-fetch/data-contracts.eta
@@ -36,7 +36,7 @@
       return `${keyName} : "${enumNames?.[idx]}"`;
     }).join(", ");
 
-    return `type ${contract.name} = keyof typeof ${mapName};  export const ${mapName} = {\r\n${map} \r\n } as const`;
+    return `type ${contract.name} = keyof typeof ${mapName};  export const ${mapName} = {\n${map} \n } as const`;
 
     },
     interface: (contract) => {
@@ -49,7 +49,7 @@
         content = content.replace(field, `${field} | null`)
       })
 
-      return `interface ${contract.name} {\r\n${content}}`;
+      return `interface ${contract.name} {\n${content}}`;
     },
     type: (contract) => {
       return `type ${contract.name} = ${contract.content}`;
@@ -85,8 +85,7 @@
 <% if (description.length) { %>
 /**
 <%~ description.map(part => `* ${part}`).join("\n") %>
-
-*/
+ */
 <% } %>
 export <%~ (dataContractTemplates[contract.typeIdentifier] || dataContractTemplates.type)(contract) %>
 

--- a/packages/cli-plugins/gen-api-react-query/templates/custom-fetch/http-client.eta
+++ b/packages/cli-plugins/gen-api-react-query/templates/custom-fetch/http-client.eta
@@ -60,7 +60,7 @@ export enum ContentType {
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-    public baseUrl: string = "<%~ apiConfig.baseUrl %>";
+    public baseUrl: string = "<%~ apiConfig.baseUrl.replace(/\/$/, '') %>";
     private securityData: SecurityDataType | null = null;
     private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
     private abortControllers = new Map<CancelToken, AbortController>();

--- a/packages/cli-plugins/gen-api-react-query/templates/my/react-query-type.eta
+++ b/packages/cli-plugins/gen-api-react-query/templates/my/react-query-type.eta
@@ -44,7 +44,7 @@ export type InfiniteQueryHookParams<
 > = {
   options?: Partial<
     Omit<
-      UseInfiniteQueryOptions<OriginData, Error, TData, OriginData, any, TPageParam>,
+      UseInfiniteQueryOptions<OriginData, Error, TData, any, TPageParam>,
       'queryKey' | 'queryFn'
     >
   >;
@@ -85,7 +85,7 @@ export type SuspenseInfiniteQueryHookParams<
 > = {
   options?: Partial<
     Omit<
-      UseSuspenseInfiniteQueryOptions<OriginData, Error, TData, OriginData, any, TPageParam>,
+      UseSuspenseInfiniteQueryOptions<OriginData, Error, TData, any, TPageParam>,
       'queryKey' | 'queryFn'
     >
   >;


### PR DESCRIPTION
## Summary
  - **출력 결정성 개선**: import 및 타입 선언 병합 시 알파벳 정렬 적용하여 실행할 때마다 동일한 결과를 보장
  - **Prettier config 탐색 개선**: cwd 의존을 제거하고 output 디렉토리 기준으로 `.prettierrc.js`를 탐색하도록 변경
  - **중복 포맷팅 제거**: `write-swagger.ts`에서 개별 파일 생성 시 수행하던 prettier 포맷팅(`generatePretty`)을 제거하고, `index.ts`의 최종 포맷팅 단계로 일원화
  - **TanStack Query v5 타입 호환성**: `UseInfiniteQueryOptions`, `UseSuspenseInfiniteQueryOptions` 제네릭 인자를 v5 시그니처(5개)에 맞게 수정
  - **템플릿 개행 정규화**: `data-contracts.eta`에서 `\r\n` → `\n` 통일, JSDoc 닫는 태그 포맷 수정
  - **baseUrl trailing slash 제거**: fetch http-client 템플릿에서 `baseUrl` 끝 `/` 자동 제거

  ## Changed Files
  | File | Description |
  |---|---|
  | `src/index.ts` | prettier config 탐색 개선, import/타입 병합 결과 정렬 |
  | `src/parse-swagger.ts` | `sortTypes`, `sortRoutes` 옵션 활성화 |
  | `src/write-swagger.ts` | `generatePretty` 제거, `generate`로 단순화 |
  | `templates/custom-axios/data-contracts.eta` | `\r\n` → `\n`, JSDoc 포맷 수정 |
  | `templates/custom-fetch/data-contracts.eta` | `\r\n` → `\n`, JSDoc 포맷 수정 |
  | `templates/custom-fetch/http-client.eta` | baseUrl trailing slash 제거 |
  | `templates/my/react-query-type.eta` | TanStack Query v5 제네릭 타입 호환성 수정 |

  ## Test Plan
  - [ ] 다양한 Swagger 스펙으로 `gen:api` 실행 후 출력 파일이 동일한지 확인 (결정성)
  - [ ] axios / fetch 모드 모두 생성된 코드가 `tsc` 에러 없이 컴파일되는지 확인
  - [ ] TanStack Query v5 프로젝트에서 생성된 훅 타입이 정상 동작하는지 확인
  - [ ] baseUrl 끝에 `/`가 있는 Swagger 스펙에서 중복 슬래시 없이 요청되는지 확인