### PR TITLE
fix(gen-api-react-query): 🐛 pnpm 10+ 엄격한 격리 환경에서 prettier 플러그인 resolv…

### DIFF
--- a/.changeset/gen-api-fix-prettier-and-import-merge.md
+++ b/.changeset/gen-api-fix-prettier-and-import-merge.md
@@ -1,0 +1,9 @@
+---
+"@toktokhan-dev/cli-plugin-gen-api-react-query": patch
+---
+
+fix(gen-api-react-query): 🐛 pnpm 10+ 엄격한 격리 환경에서 `prettier-plugin-organize-imports` resolve 실패 및 재실행 시 import 중복으로 인한 파일 손상 수정
+
+- `index.ts`의 `gen:api` 최종 Prettier 포맷 패스(`withLoading('Prettier format', ...)`)에서 `prettier-plugin-organize-imports`를 패키지 이름 문자열로 넘기던 것을 `require.resolve()`로 바꿔, pnpm 10 이상의 엄격한 의존성 격리 환경에서도 항상 resolve 되도록 수정했습니다. 이 실패는 크래시로 드러나지 않고 인접한 `catch {}`에 조용히 삼켜져 import 정리가 그냥 스킵되던 형태로도 나타났습니다.
+- `mergeTypeScriptContent`의 import 병합 로직이 quote(`'`/`"`)·세미콜론 스타일 차이만 있는 동일 import를 별개로 취급해 재실행마다 중복이 누적되고, 결국 `Identifier has already been declared` 문법 에러로 생성 파일이 영구히 손상되던 문제를 수정했습니다. 이제 정규화된 키로 비교해 동일 import는 하나로 병합됩니다(새 내용 우선, 기존에만 있는 import는 보존).
+  - swagger-typescript-api의 내부 포맷(prettier 기본값: 쌍따옴표+세미콜론)과 소비 프로젝트의 `.prettierrc.js` 포맷이 다른 근본 원인 자체는 남아 있습니다 — 이번 수정은 그 불일치를 병합 단계에서 흡수하는 것입니다.

--- a/packages/cli-plugins/gen-api-react-query/src/__tests__/write-swagger.test.ts
+++ b/packages/cli-plugins/gen-api-react-query/src/__tests__/write-swagger.test.ts
@@ -427,6 +427,29 @@ describe('mergeTypeScriptContent', () => {
     expect(importMatches.length).toBe(3) // A, B, C
   })
 
+  it('quote/세미콜론 스타일만 다른 동일 import 는 중복시키지 않는다', () => {
+    // swagger-typescript-api 의 내부 prettier 설정(쌍따옴표+세미콜론)과 소비 프로젝트의
+    // .prettierrc.js(홑따옴표, 세미콜론 없음)가 서로 달라, 재실행마다 같은 import가
+    // 문자열만 다르게 누적되고 결국 "Identifier has already been declared" 로 파일이
+    // 영구히 손상되던 버그의 회귀 테스트.
+    const existing = `import axios from 'axios'\n\nexport const a = 1\n`
+    const newContent = `import axios from "axios";\n\nexport const a = 1;\n`
+
+    const result = mergeTypeScriptContent(existing, newContent)
+
+    expect(result.match(/^import axios/gm)).toHaveLength(1)
+  })
+
+  it('내용이 다른 import 는 quote 정규화와 무관하게 별개로 유지한다', () => {
+    const existing = `import { A } from './a'\n\nexport const a = 1\n`
+    const newContent = `import { B } from "./b";\n\nexport const a = 1;\n`
+
+    const result = mergeTypeScriptContent(existing, newContent)
+
+    expect(result).toContain("import { A } from './a'")
+    expect(result).toContain('import { B } from "./b";')
+  })
+
   it('preserves header from new content', () => {
     const existing = `/* old header */\nexport type X = string`
     const newContent = `/* new header */\nexport type X = string`

--- a/packages/cli-plugins/gen-api-react-query/src/index.ts
+++ b/packages/cli-plugins/gen-api-react-query/src/index.ts
@@ -184,6 +184,11 @@ export const genApi = defineCommand<'gen:api', GenerateSwaggerApiConfig>({
       await withLoading('Prettier format', covered.output, async () => {
         const fs = await import('fs')
         const pathMod = await import('path')
+        // `import.meta.url` 대신 __filename 을 앵커로 쓴다 — 이 패키지의 다른 파일
+        // (package-root.ts)과 동일한 패턴으로, Rollup ESM 빌드에서는 자동 shim이 주입되고
+        // ts-jest(CJS 트랜스파일) 환경에서는 네이티브 전역으로 그대로 동작한다.
+        const { createRequire } = await import('module')
+        const require = createRequire(__filename)
         const { prettierString, findFileToTop } = await import(
           '@toktokhan-dev/node'
         )
@@ -213,7 +218,7 @@ export const genApi = defineCommand<'gen:api', GenerateSwaggerApiConfig>({
             try {
               organized = await prettierString(raw, {
                 parser: 'babel-ts',
-                plugins: ['prettier-plugin-organize-imports'],
+                plugins: [require.resolve('prettier-plugin-organize-imports')],
               })
             } catch {
               // prettier-plugin-organize-imports not installed, skip
@@ -246,25 +251,41 @@ export function mergeTypeScriptContent(
   const importRegex = /^\s*import\s+[\s\S]*?from\s*['"][^'"]*['"];?/gm
   const sideEffectImportRegex = /^\s*import\s*['"][^'"]+['"];\s*$/gm
 
+  // quote(', ")·세미콜론·공백 차이만 있는 import 는 같은 import 로 취급한다.
+  // (swagger-typescript-api 의 내부 포맷과 소비 프로젝트의 .prettierrc.js 가 서로 다른
+  // quote/세미콜론 스타일을 쓰는 경우가 흔해서, 문자열 그대로 비교하면 예: `import axios
+  // from "axios";` 와 `import axios from 'axios'` 가 별개로 취급되어 매 실행마다 누적되고,
+  // 결국 "Identifier has already been declared" 문법 에러로 파일이 영구히 손상된다.)
+  const normalizeImportKey = (line: string) =>
+    line
+      .replace(/\s+/g, ' ')
+      .trim()
+      .replace(/;$/, '')
+      .replace(/"/g, "'")
+
   const collectImports = (content: string) => {
-    const imports = new Set<string>()
+    const imports = new Map<string, string>()
     const matchedA = content.match(importRegex) ?? []
     const matchedB = content.match(sideEffectImportRegex) ?? []
-    ;[...matchedA, ...matchedB].forEach((line) => imports.add(line.trim()))
+    ;[...matchedA, ...matchedB].forEach((line) => {
+      const trimmed = line.trim()
+      imports.set(normalizeImportKey(trimmed), trimmed)
+    })
     const contentWithoutImports = content
       .replace(importRegex, '')
       .replace(sideEffectImportRegex, '')
-    return { imports: Array.from(imports), body: contentWithoutImports }
+    return { imports, body: contentWithoutImports }
   }
 
   const { imports: existingImports, body: existingBody } =
     collectImports(existing)
   const { imports: newImports, body: newBody } = collectImports(newContent)
 
-  // import 병합: 새 파일 기준 우선 순서 + 기존에만 있는 import 추가
-  const mergedImportSet = new Set<string>(newImports)
-  existingImports.forEach((imp) => mergedImportSet.add(imp))
-  const mergedImports = Array.from(mergedImportSet).sort()
+  // import 병합: 동일 import(정규화 키 기준)는 새 파일 내용이 우선하고,
+  // 기존에만 있던 import 는 그대로 보존한다.
+  const mergedImportMap = new Map<string, string>(existingImports)
+  newImports.forEach((line, key) => mergedImportMap.set(key, line))
+  const mergedImports = Array.from(mergedImportMap.values()).sort()
 
   // 2) 타입 선언 병합 (중복 제거)
   const existingTypes = parseTypeDefinitions(existingBody)


### PR DESCRIPTION
…e 실패 및 import 중복 손상 수정

- generatePretty 최종 Prettier 포맷 단계에서 prettier-plugin-organize-imports를 패키지 이름 문자열로 넘기던 것을 require.resolve()로 교체. pnpm 10+ 엄격한 의존성 격리 환경에서 resolve 실패가 크래시 없이 catch{}에 조용히 삼켜져 import 정리 단계가 스킵되는 형태로 나타났음.
- mergeTypeScriptContent의 import 병합이 quote(''/"")·세미콜론 스타일 차이만 있는 동일 import를 별개로 취급해 재실행마다 중복이 누적되고, 결국 "Identifier has already been declared" 문법 에러로 생성 파일이 영구 손상되던 문제 수정. 정규화된 키로 비교해 동일 import는 새 내용 우선으로 병합.
- 회귀 테스트 2건 추가, changeset(patch) 추가.

실제 pnpm@11.5.0 + Node 24 환경(격리 worktree)에서 install/build/test 전체 통과 확인.